### PR TITLE
fix: when generating sm2, opts is nil will cause hash func validate throw error

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -16,10 +16,10 @@ import (
 	"io"
 	"math/big"
 
-	_ "github.com/crpt/go-crpt/sm3"
 	gsm2 "github.com/emmansun/gmsm/sm2"
 
 	"github.com/crpt/go-crpt"
+	_ "github.com/crpt/go-crpt/sm3"
 )
 
 const (
@@ -106,13 +106,7 @@ func NewPublicKey(b []byte, opts crpt.SignerOpts) (*PublicKey, error) {
 	if len(b) != PublicKeySize {
 		return nil, ErrWrongPublicKeySize
 	}
-	if opts == nil {
-		return nil, errors.New("sm2: opts is nil")
-	}
-	so, ok := opts.(*SignerOpts)
-	if !ok {
-		return nil, errors.New("sm2: opts is not of type *SignerOpts")
-	}
+	so := crpt.ConvertSignerOpts(opts, DefaultSignerOpts)
 	ecdsaPub, err := gsm2.NewPublicKey(b)
 	if err != nil {
 		return nil, err

--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"math/big"
 
+	_ "github.com/crpt/go-crpt/sm3"
 	gsm2 "github.com/emmansun/gmsm/sm2"
 
 	"github.com/crpt/go-crpt"


### PR DESCRIPTION

- import unused `sm3` package to trigger `init()` func which is used to register the hash function during setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies for enhanced system compatibility.
  * Improved key initialization robustness: missing or incorrect initialization options are now defaulted rather than causing initialization failures, reducing setup errors and improving stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->